### PR TITLE
Suppression du contrôle de frappe sur le GAD

### DIFF
--- a/desktop/js/eibd.js
+++ b/desktop/js/eibd.js
@@ -206,13 +206,13 @@ $('body').on( 'click','.bt_read', function() {
 	});
 });
 $('body').on('keyup','.cmdAttr[data-l1key=logicalId]', function() {
-	var Gad=$(this).val().split('/');
+	/*var Gad=$(this).val().split('/');
 	if($.isNumeric(Gad[Gad.length - 1])){
 		if(Gad[Gad.length - 1]==0 || Gad[Gad.length - 1]>254)
 			$(this).val($(this).val()+'/');
 	}
 	if($(this).val().substr(-2) =='//' || Gad.length>3)
-		$(this).val($(this).val().substring(0,$(this).val().length-1));
+		$(this).val($(this).val().substring(0,$(this).val().length-1));*/
 }); 
 $('body').on('change','.cmdAttr[data-l1key=configuration][data-l2key=KnxObjectType]', function() {
 	DptOption($(this).val(),$(this).closest('.cmd').find('.option'));


### PR DESCRIPTION
Suppression du contrôle de frappe sur le gad, l'information du nombre de niveau sur le js est manquante (a récupérer en config)