### PR TITLE
add specific config file for Atlas

### DIFF
--- a/core/config/specific.config.ini
+++ b/core/config/specific.config.ini
@@ -1,0 +1,3 @@
+[atlas]
+  eibd[TypeKNXgateway] = ft12cemi
+  eibd[KNXgateway] = /dev/ttyS2


### PR DESCRIPTION
Salut Mika,

Je te propose d'inclure la configuration automatique de ton plugin pour la box Atlas _(disponible à compter de Jeedom 4.5.3)_ : 

jeedom/core#3218

### Changelog suggéré : 
># 17/03/2026
>
>- Configuration automatique du plugin sur la box Jeedom Atlas *(Jeedom 4.5.3 mini)*