### PR TITLE
Répare le TypeKNXgateway lors de la mise à jour d'une Atlas

### DIFF
--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -1,7 +1,48 @@
 <?php
 require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
+/*
+ * Depuis specific.config.ini, le type de passerelle par défaut sur Atlas (Pro ou pas) est maintenant ft12cemi (KNX intégré sur /dev/ttyS2).
+ * Le cœur Jeedom ne stocke pas en base une valeur égale au défaut : les installations Atlas qui utilisaient
+ * l'ancien défaut (ipt) avec une passerelle IP se retrouvent donc en ft12cemi après mise à jour.
+ * Cela casse silencieusement les configurations, si l'utilisateur n'est pas averti.
+ * On rétablit ipt explicitement quand la passerelle configurée avant la mise à jour n'est pas un périphérique série.
+ */
+function eibd_migrateGatewayType() {
+	/*
+	Si la config ne renvoie pas ft12cemi comme Type de passerelle,
+	-On est sur une box non atlas avec l'ancien défaut, ou avec un TypeKNXgateway persisté
+	-On est sur une Atlas avec un type différent du nouveau défaut persisté
+	On ne fait rien.
+	*/
+	if(config::byKey('TypeKNXgateway', 'eibd') != 'ft12cemi')
+		return;
+
+	/*
+	Si aucune passerelle n'est configurée, c'est une installation propre, on ne fait rien.
+	*/
+	$gateway = trim(config::byKey('KNXgateway', 'eibd'));
+	if($gateway == '')
+		return;
+
+	/*
+	Si la passerelle commence par un slash, c'est une interface série physique sur une Atlas ou un adaptateur USB, etc.
+	On laisse ft12cemi qui est cohérent.
+	*/
+	if(strpos($gateway, '/') === 0)
+		return;
+
+	/*
+	Sinon, on a une IP ou un nom d'hôte comme passerelle, mais un Type de passerelle sur ft12cemi.
+	Il faut agir, et redéfinir explicitement l'ancien défaut ipt comme type de passerelle
+	pour que ça soit persisté en base et pas écrasé par la mise à jour.
+	*/
+	config::save('TypeKNXgateway', 'ipt', 'eibd');
+	log::add('eibd','info','[Mise à jour] Type de passerelle rétabli en IP Tunnelling (ipt) pour la passerelle '.$gateway);
+}
 function eibd_update() {
-	log::add('eibd','debug','Lancement du script de mise à jour'); 
+	log::add('eibd','debug','Lancement du script de mise à jour');
+	//On appelle notre fonction de vérification
+	eibd_migrateGatewayType();
 	$oldPath = dirname(__FILE__) . '/../core/config/';
 	$File = 'KnxProj.json';
 	if(file_exists($oldPath.$File)){


### PR DESCRIPTION
La dernière mise à jour force le TypeKNXgateway sur ft12cemi dans deux cas spécifiques:
1-Install propre sur une box ATLAS ou ATLAS Pro (a priori, Jeedom ne fait pas la différence quand on lui demande sur quel hardware on est)
2-Mise à jour sur une ATLAS ou ATLAS Pro qui n'avait pas de TypeKNXgateway persisté, donc était sur l'ancien défaut ipt.

Problème, dans le cas numéro 2, la config était cassée, avec un TypeKNXgateway ft12cemi, mais un KNXgateway ne contenant pas un port série.

Cet ajout de code est une protection, qui force la valeur du type sur l'ancien défaut si elle n'a pas été persistée et que la passerelle ne ressemble pas à un port série.

Bonne jouréne.